### PR TITLE
change location of debian security packages

### DIFF
--- a/templates/etc/apt/sources.list.j2
+++ b/templates/etc/apt/sources.list.j2
@@ -7,7 +7,7 @@
 {{ item }} {{ apt_sources_debian_repository_url }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }}-backports main
 {%     endif %}
 {%     if apt_sources_enable_security %}
-{{ item }} {{ apt_sources_debian_repository_url }}/{{ ansible_distribution|lower }}-security {{ apt_sources_debian_distribution }}/updates main
+{{ item }} {{ apt_sources_debian_repository_url }}/{{ ansible_distribution|lower }}-security {{ apt_sources_debian_distribution }}-security main
 {%     endif %}
 {%     if apt_sources_enable_updates %}
 {{ item }} {{ apt_sources_debian_repository_url }}/{{ ansible_distribution|lower }} {{ apt_sources_debian_distribution }}-updates {{ apt_sources_debian_components|join (' ') }}


### PR DESCRIPTION

## Description
the packages of debian security are located in the following path : "debian-security/dists/stable-security/"

## Related Issue
https://github.com/mrlesmithjr/ansible-apt-sources/issues/9

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
